### PR TITLE
Add repr method to DisjointMemoryRegion class

### DIFF
--- a/tool/microkit/util.py
+++ b/tool/microkit/util.py
@@ -208,3 +208,5 @@ class DisjointMemoryRegion:
 
         return region.base
 
+    def __repr__(self) -> str:
+        return " ".join(map(lambda x: "0x%x->0x%x" %(x.base, x.base + x.size), self._regions))


### PR DESCRIPTION
To aid in debugging, it's useful to be able to print out the contents of the memory regions.