### PR TITLE
Added support for smp gettriggercore

### DIFF
--- a/tool/microkit/__main__.py
+++ b/tool/microkit/__main__.py
@@ -1305,6 +1305,7 @@ def build_system(
             cap_slot += 1
             cap_address_names[cap_address] = f"IRQ Handler: irq={sysirq.irq:d}"
             irq_cap_addresses[pd].append(cap_address)
+
     # This has to be done prior to minting!
     # for vspace_obj in vspace_objects:
     #     system_invocations.append(Sel4AsidPoolAssign(INIT_ASID_POOL_CAP_ADDRESS, vspace_obj.cap_addr))

--- a/tool/microkit/sel4.py
+++ b/tool/microkit/sel4.py
@@ -755,7 +755,6 @@ class Sel4Label(IntEnum):
     # ARM IRQ
     ARMIRQIssueIRQHandlerTrigger = 57
     ARMIRQIssueIRQHandlerTriggerCore = 58
-
     # RISC-V Page Table
     RISCVPageTableMap = 59
     RISCVPageTableUnmap = 60
@@ -769,7 +768,6 @@ class Sel4Label(IntEnum):
     # RISC-V IRQ
     RISCVIRQIssueIRQHandlerTrigger = 66
     RISCVIRQIssueIRQHandlerTriggerCore = 67
-
     # RISC-V VCPU
     RISCVVCPUSetTCB = 68
     RISCVVCPUReadReg = 69
@@ -799,7 +797,6 @@ AARCH64_LABELS = {
     # ARM IRQ
     Sel4Label.ARMIRQIssueIRQHandlerTrigger: 52,
     Sel4Label.ARMIRQIssueIRQHandlerTriggerCore: 53
-
 }
 
 AARCH64_HYP_LABELS = {
@@ -812,7 +809,6 @@ AARCH64_HYP_LABELS = {
     # ARM IRQ
     Sel4Label.ARMIRQIssueIRQHandlerTrigger: 57,
     Sel4Label.ARMIRQIssueIRQHandlerTriggerCore: 58
-
 }
 
 RISCV_LABELS = {

--- a/tool/microkit/sysxml.py
+++ b/tool/microkit/sysxml.py
@@ -74,6 +74,7 @@ class SysIrq:
     irq: int
     id_: int
     trigger: str
+    target: int
 
 
 @dataclass(frozen=True, eq=True)
@@ -217,9 +218,9 @@ class SystemDescription:
         all_irqs = set()
         for pd in self.protection_domains:
             for sysirq in pd.irqs:
-                if sysirq.irq in all_irqs:
+                if (sysirq.irq, sysirq.target) in all_irqs:
                     raise UserError(f"duplicate irq: {sysirq.irq} in protection domain: '{pd.name}' @ {pd.element._loc_str}")  # type: ignore
-                all_irqs.add(sysirq.irq)
+                all_irqs.add((sysirq.irq, sysirq.target))
 
         # Ensure no duplicate channel identifiers
         ch_ids: Dict[str, Set[int]] = {pd_name: set() for pd_name in self.pd_by_name}
@@ -362,7 +363,8 @@ def xml2pd(pd_xml: ET.Element, plat_desc: PlatformDescription, is_child: bool=Fa
                     trigger = Sel4ArmIrqTrigger.Edge
                 else:
                     raise UserError(f"Invalid IRQ trigger '{trigger_str}': {child._loc_str}")
-                irqs.append(SysIrq(irq, irq_id, trigger))
+                target = cpu
+                irqs.append(SysIrq(irq, irq_id, trigger, target))
             elif child.tag == "setvar":
                 _check_attrs(child, ("symbol", "region_paddr"))
                 symbol = checked_lookup(child, "symbol")


### PR DESCRIPTION
Added in the use of IRQGetTriggerCore for SMP configurations. This allows us to set a CPU affinity for IRQ's. This is not user-set, and defaults to the CPU affinity of the PD that the IRQ is a child of.