### PR TITLE
Ignore non loadable segments

### DIFF
--- a/tool/microkit/__main__.py
+++ b/tool/microkit/__main__.py
@@ -305,7 +305,7 @@ def phys_mem_regions_from_elf(elf: ElfFile, alignment: int) -> List[MemoryRegion
             round_down(segment.phys_addr, alignment),
             round_up(segment.phys_addr + len(segment.data), alignment)
         )
-        for segment in elf.segments
+        for segment in elf.segments if segment.loadable
     ]
 
 
@@ -333,7 +333,7 @@ def virt_mem_regions_from_elf(elf: ElfFile, alignment: int) -> List[MemoryRegion
             round_down(segment.virt_addr, alignment),
             round_up(segment.virt_addr + len(segment.data), alignment)
         )
-        for segment in elf.segments
+        for segment in elf.segments if segment.loadable
     ]
 
 

--- a/tool/microkit/elf.py
+++ b/tool/microkit/elf.py
@@ -299,6 +299,10 @@ class ElfFile:
                 f.seek(hdr.phoff + idx * hdr.phentsize)
                 phent_raw = f.read(hdr.phentsize)
                 phent = ElfProgramHeader(**dict(zip(ph_fields, ph_fmt.unpack_from(phent_raw))))
+
+                if phent.type_ != SegmentType.PT_LOAD:
+                    continue
+
                 f.seek(phent.offset)
                 data = f.read(phent.filesz)
                 zeros = bytes(phent.memsz - phent.filesz)

--- a/tool/microkit/elf.py
+++ b/tool/microkit/elf.py
@@ -300,12 +300,14 @@ class ElfFile:
                 phent_raw = f.read(hdr.phentsize)
                 phent = ElfProgramHeader(**dict(zip(ph_fields, ph_fmt.unpack_from(phent_raw))))
 
-                if phent.type_ != SegmentType.PT_LOAD:
-                    continue
-
                 f.seek(phent.offset)
                 data = f.read(phent.filesz)
-                zeros = bytes(phent.memsz - phent.filesz)
+
+                if phent.memsz - phent.filesz < 0:
+                    zeros = bytes(0)
+                else:
+                    zeros = bytes(phent.memsz - phent.filesz)
+
                 elf.segments.append(ElfSegment(phent.paddr, phent.vaddr, bytearray(data + zeros), phent.type_ == 1, SegmentAttributes(phent.flags)))
 
 


### PR DESCRIPTION
Ignore non loadable segment in `phys_mem_regions_from_elf()` and `virt_mem_regions_from_elf()` in `tool/microkit/__main__.py`.