### PR TITLE
RISC-V --- set up global pointer

### DIFF
--- a/libmicrokit/microkit.ld
+++ b/libmicrokit/microkit.ld
@@ -40,7 +40,8 @@ SECTIONS
     {
         _data = .;
         *(.data)
-	__global_pointer$ = . + 0x800
+	. = ALIGN(8);
+	__global_pointer$ = . + 0x800;
 	*(.srodata)
 	*(.sdata)
         _data_end = .;

--- a/libmicrokit/microkit.ld
+++ b/libmicrokit/microkit.ld
@@ -40,12 +40,15 @@ SECTIONS
     {
         _data = .;
         *(.data)
+	*(.srodata)
+	*(.sdata)
         _data_end = .;
     } :data
 
     .bss :
     {
         _bss = .;
+	*(.sbss)
         *(.bss)
         *(COMMON)
         . = ALIGN(4);

--- a/libmicrokit/microkit.ld
+++ b/libmicrokit/microkit.ld
@@ -40,6 +40,7 @@ SECTIONS
     {
         _data = .;
         *(.data)
+	__global_pointer$ = . + 0x800
 	*(.srodata)
 	*(.sdata)
         _data_end = .;

--- a/libmicrokit/src/riscv/crt0.s
+++ b/libmicrokit/src/riscv/crt0.s
@@ -1,4 +1,5 @@
 .extern main
+.extern __global_pointer$
 
 .section ".text.start"
 

--- a/libmicrokit/src/riscv/crt0.s
+++ b/libmicrokit/src/riscv/crt0.s
@@ -5,6 +5,11 @@
 .global _start;
 .type _start, %function;
 _start:
+.option push
+.option norelax
+1:  auipc gp, %pcrel_hi(__global_pointer$)
+    addi  gp, gp, %pcrel_lo(1b)
+.option pop
     la s1, (_stack + 0xff0)
     mv sp, s1
     j main

--- a/loader/src/riscv/loader.ld
+++ b/loader/src/riscv/loader.ld
@@ -23,15 +23,18 @@ SECTIONS
 
     .data :
     {
-        __global_pointer$ = . + 0x800;
         _data = .;
-        *(.data)
-        _data_end = .;
+        *(.data) 
+        __global_pointer$ = . + 0x800;
+	*(.srodata)
+	*(.sdata)
+       _data_end = .;
     } :all
 
     .bss :
     {
         _bss = .;
+	*(.sbss)
         *(.bss)
         *(COMMON)
         . = ALIGN(4);

--- a/monitor/monitor.ld
+++ b/monitor/monitor.ld
@@ -25,12 +25,16 @@ SECTIONS
     {
         _data = .;
         *(.data)
+        __global_pointer$ = . + 0x800;
+	*(.srodata)
+	*(.sdata)
         _data_end = .;
     } :all
 
     .bss :
     {
         _bss = .;
+	*(.sbss)
         *(.bss)
         *(COMMON)
         . = ALIGN(4);

--- a/monitor/src/riscv64/crt0.s
+++ b/monitor/src/riscv64/crt0.s
@@ -1,10 +1,16 @@
 .extern main
+.extern __global_pointer$
 
 .section ".text.start"
 
 .global _start;
 .type _start, %function;
 _start:
+.option push
+.option norelax
+1:  auipc gp, %pcrel_hi(__global_pointer$)
+    addi  gp, gp, %pcrel_lo(1b)
+.option pop
     la s1, (_stack + 0xff0)
     mv sp, s1
     j main


### PR DESCRIPTION
The RISC-V compilers try to put frequently used data into  'small data' and 'small BSS' sections that are meant to be within 2k of the global pointer.

This patch includes sbss and sdata into the appropriate segments, and sets the global pointer to a point 2k from the start of small data.